### PR TITLE
Split and tidy up declarations

### DIFF
--- a/versions/draft-3/parsers/grammar.hgr
+++ b/versions/draft-3/parsers/grammar.hgr
@@ -313,7 +313,7 @@ grammar {
 
     # Task Definition: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#task-definition
     $task = :task :identifier :lbrace list($task_sections) :rbrace -> Task(name=$1, declarations=$3, sections=$4)
-    $task_sections = $command | $inputs | $outputs | $runtime | $parameter_meta | $meta | $set_declaration
+    $task_sections = $command | $inputs | $outputs | $runtime | $parameter_meta | $meta | $declaration
     $command = :raw_command :raw_cmd_start list($command_part) :raw_cmd_end -> RawCommand(parts=$2)
     $command_part = :cmd_part | $cmd_param
     $cmd_param = :cmd_param_start list($cmd_param_kv) $e :cmd_param_end -> CommandParameter(attributes=$1, expr=$2)
@@ -327,7 +327,7 @@ grammar {
 
     # Declarations: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#declarations
     $input_declaration = $type_e :identifier optional($setter) -> InputDeclaration(type=$0, name=$1, expression=$2)
-    $set_declaration = $type_e :identifier $setter -> Declaration(type=$0, name=$1, expression=$2)
+    $declaration = $type_e :identifier $setter -> Declaration(type=$0, name=$1, expression=$2)
     $setter = :equal $e -> $1
 
     # Types: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#types
@@ -379,7 +379,7 @@ grammar {
 
     # Workflows: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#workflow-definition
     $workflow = :workflow :identifier :lbrace list($wf_body_element) :rbrace -> Workflow(name=$1, body=$3)
-    $wf_body_element = $call | $set_declaration | $while_loop | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
+    $wf_body_element = $call | $declaration | $while_loop | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
     $call = :call :fqn optional($alias) optional($call_body) -> Call(task=$1, alias=$2, body=$3)
     $call_body = :lbrace :input :colon list($object_kv, :comma) :rbrace -> CallBody(inputs=$3)
     $alias = :as :identifier -> $1

--- a/versions/draft-3/parsers/grammar.hgr
+++ b/versions/draft-3/parsers/grammar.hgr
@@ -381,9 +381,7 @@ grammar {
     $workflow = :workflow :identifier :lbrace list($wf_body_element) :rbrace -> Workflow(name=$1, body=$3)
     $wf_body_element = $call | $set_declaration | $while_loop | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
     $call = :call :fqn optional($alias) optional($call_body) -> Call(task=$1, alias=$2, body=$3)
-    $call_body = :lbrace list($call_input) :rbrace -> CallBody(inputs=$1)
-    $call_input = :input :colon list($mapping, :comma) -> Inputs(map=$2)
-    $mapping = :identifier :equal $e -> IOMapping(key=$0, value=$2)
+    $call_body = :lbrace :input :colon list($object_kv, :comma) :rbrace -> CallBody(inputs=$3)
     $alias = :as :identifier -> $1
     $wf_parameter_meta = :parameter_meta $map -> ParameterMeta(map=$1)
     $wf_meta = :meta $map -> Meta(map=$1)

--- a/versions/draft-3/parsers/grammar.hgr
+++ b/versions/draft-3/parsers/grammar.hgr
@@ -301,8 +301,8 @@ grammar {
   }
   parser {
     # Document: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#document
-    $document = $version list($import) list($workflow_or_task_or_decl) -> Draft3File(version=$0, imports=$1, body=$2)
-    $workflow_or_task_or_decl = $workflow | $task | $declaration
+    $document = $version list($import) list($workflow_or_task) -> Draft3File(version=$0, imports=$1, body=$2)
+    $workflow_or_task = $workflow | $task
 
     # Version declaration:
     $version = :version :version_name -> VersionDeclaration(v = $1)
@@ -312,13 +312,13 @@ grammar {
     $import_namespace = :as :identifier -> $1
 
     # Task Definition: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#task-definition
-    $task = :task :identifier :lbrace list($declaration) list($sections) :rbrace -> Task(name=$1, declarations=$3, sections=$4)
-    $sections = $command | $inputs | $outputs | $runtime | $parameter_meta | $meta
+    $task = :task :identifier :lbrace list($task_sections) :rbrace -> Task(name=$1, declarations=$3, sections=$4)
+    $task_sections = $command | $inputs | $outputs | $runtime | $parameter_meta | $meta | $set_declaration
     $command = :raw_command :raw_cmd_start list($command_part) :raw_cmd_end -> RawCommand(parts=$2)
     $command_part = :cmd_part | $cmd_param
     $cmd_param = :cmd_param_start list($cmd_param_kv) $e :cmd_param_end -> CommandParameter(attributes=$1, expr=$2)
     $cmd_param_kv = :cmd_attr_hint :identifier :equal $e -> CommandParameterAttr(key=$1, value=$3)
-    $inputs = :input :lbrace list($declaration) :rbrace -> Inputs(inputs=$2)
+    $inputs = :input :lbrace list($input_declaration) :rbrace -> Inputs(inputs=$2)
     $runtime = :runtime $map -> Runtime(map=$1)
     $parameter_meta = :parameter_meta $map -> ParameterMeta(map=$1)
     $meta = :meta $map -> Meta(map=$1)
@@ -326,7 +326,8 @@ grammar {
     $kv = :identifier :colon $e -> RuntimeAttribute(key=$0, value=$2)
 
     # Declarations: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#declarations
-    $declaration = $type_e :identifier optional($setter) -> Declaration(type=$0, name=$1, expression=$2)
+    $input_declaration = $type_e :identifier optional($setter) -> InputDeclaration(type=$0, name=$1, expression=$2)
+    $set_declaration = $type_e :identifier $setter -> SetDeclaration(type=$0, name=$1, expression=$2)
     $setter = :equal $e -> $1
 
     # Types: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#types
@@ -378,9 +379,9 @@ grammar {
 
     # Workflows: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#workflow-definition
     $workflow = :workflow :identifier :lbrace list($wf_body_element) :rbrace -> Workflow(name=$1, body=$3)
-    $wf_body_element = $call | $declaration | $while_loop | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
+    $wf_body_element = $call | $set_declaration | $while_loop | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
     $call = :call :fqn optional($alias) optional($call_body) -> Call(task=$1, alias=$2, body=$3)
-    $call_body = :lbrace list($declaration) list($call_input) :rbrace -> CallBody(declarations=$1, io=$2)
+    $call_body = :lbrace list($call_input) :rbrace -> CallBody(inputs=$1)
     $call_input = :input :colon list($mapping, :comma) -> Inputs(map=$2)
     $mapping = :identifier :equal $e -> IOMapping(key=$0, value=$2)
     $alias = :as :identifier -> $1

--- a/versions/draft-3/parsers/grammar.hgr
+++ b/versions/draft-3/parsers/grammar.hgr
@@ -327,7 +327,7 @@ grammar {
 
     # Declarations: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#declarations
     $input_declaration = $type_e :identifier optional($setter) -> InputDeclaration(type=$0, name=$1, expression=$2)
-    $set_declaration = $type_e :identifier $setter -> SetDeclaration(type=$0, name=$1, expression=$2)
+    $set_declaration = $type_e :identifier $setter -> Declaration(type=$0, name=$1, expression=$2)
     $setter = :equal $e -> $1
 
     # Types: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#types


### PR DESCRIPTION
* Split declarations into InputDeclaration (setter optional) and SetDeclaration (setter required)
* Don't allow top level declarations (which were never supported)
* Tidy up call body (why were declarations allowed there!?!)