### PR TITLE
Allow parens in strings (Java)

### DIFF
--- a/versions/draft-3/parsers/grammar.hgr
+++ b/versions/draft-3/parsers/grammar.hgr
@@ -90,7 +90,7 @@ grammar {
       r'~\{' -> :expression_placeholder_start @expression_placeholder
       enum {
         python: r'[^\"\n(\$\{)(~\{)]*'
-        java: "[^\"\\n(${)(~{)]*"
+        java: "(.*?)(?=\\$\\{|~\\{|\")"
         javascript: "[^\\\\\\\"\\n(${)(~{)]*"
       } -> :string
     }
@@ -101,7 +101,7 @@ grammar {
       r'~\{' -> :expression_placeholder_start @expression_placeholder
       enum {
         python: r'[^\'\n(\$\{)(~\{)]*'
-        java: "[^'\\n(${)(~{)]*"
+        java: "(.*?)(?=\\$\\{|~\\{|')"
         javascript: "[^'\\n(${)(~{)]*"
       } -> :string
     }


### PR DESCRIPTION
Still todo:
- [ ] In python
- [ ] in javascript